### PR TITLE
A few hacks to refresh ndn-with-docker

### DIFF
--- a/debian-jessie/Dockerfile
+++ b/debian-jessie/Dockerfile
@@ -27,4 +27,9 @@ RUN /scripts/install-ndn-cxx.sh
 ADD ./scripts/install-nfd.sh /scripts/
 RUN /scripts/install-nfd.sh
 
-CMD /usr/local/bin/nfd-start-fg
+RUN ndnsec-keygen /localhost/operator | ndnsec-install-cert -
+# fix nfd-start for docker
+RUN perl -pi -e 's/bash/bash -i/' /bin/nfd-start
+RUN echo 'fg'>> /bin/nfd-start
+
+CMD /bin/nfd-start

--- a/debian-jessie/Dockerfile
+++ b/debian-jessie/Dockerfile
@@ -9,6 +9,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libpcap-dev libcrypto++-de
 # Missing dependencies: http://redmine.named-data.net/issues/2013
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y procps psmisc sudo
 
+ENV NDN_CXX_REPO https://github.com/named-data/ndn-cxx.git
+ENV NDN_CXX_VERSION ndn-cxx-0.4.1
+
+ENV NDN_NFD_REPO https://github.com/named-data/NFD.git
+ENV NDN_NFD_VERSION NFD-0.4.1
+
 RUN mkdir -p /scripts /source
 
 ADD ./scripts/install-ndn-cxx.sh /scripts/

--- a/debian-jessie/Dockerfile
+++ b/debian-jessie/Dockerfile
@@ -17,11 +17,13 @@ ENV NDN_NFD_VERSION NFD-0.4.1
 
 RUN mkdir -p /scripts /source
 
+# First checkout sources, so it's easier to just rebuild changing options
 RUN cd /source && git clone --recursive ${NDN_CXX_REPO}
+RUN cd /source && git clone --recursive ${NDN_NFD_REPO}
+
 ADD ./scripts/install-ndn-cxx.sh /scripts/
 RUN /scripts/install-ndn-cxx.sh
 
-RUN cd /source && git clone --recursive ${NDN_NFD_REPO}
 ADD ./scripts/install-nfd.sh /scripts/
 RUN /scripts/install-nfd.sh
 

--- a/debian-jessie/Dockerfile
+++ b/debian-jessie/Dockerfile
@@ -17,9 +17,11 @@ ENV NDN_NFD_VERSION NFD-0.4.1
 
 RUN mkdir -p /scripts /source
 
+RUN cd /source && git clone --recursive ${NDN_CXX_REPO}
 ADD ./scripts/install-ndn-cxx.sh /scripts/
 RUN /scripts/install-ndn-cxx.sh
 
+RUN cd /source && git clone --recursive ${NDN_NFD_REPO}
 ADD ./scripts/install-nfd.sh /scripts/
 RUN /scripts/install-nfd.sh
 

--- a/debian-jessie/scripts/install-ndn-cxx.sh
+++ b/debian-jessie/scripts/install-ndn-cxx.sh
@@ -8,10 +8,10 @@
 set -e
 cd /source
 
-git clone --depth 1 https://github.com/named-data/ndn-cxx.git
+git clone ${NDN_CXX_REPO}
 pushd ./ndn-cxx
-  git checkout -b release-build ndn-cxx-0.2.0
-  ./waf configure
+  git checkout -b build ${NDN_CXX_VERSION}
+  ./waf configure --prefix=/usr
   ./waf
   ./waf install
 popd

--- a/debian-jessie/scripts/install-ndn-cxx.sh
+++ b/debian-jessie/scripts/install-ndn-cxx.sh
@@ -8,7 +8,6 @@
 set -e
 cd /source
 
-git clone ${NDN_CXX_REPO}
 pushd ./ndn-cxx
   git checkout -b build ${NDN_CXX_VERSION}
   ./waf configure --prefix=/usr

--- a/debian-jessie/scripts/install-nfd.sh
+++ b/debian-jessie/scripts/install-nfd.sh
@@ -8,7 +8,6 @@
 set -e
 cd /source
 
-git clone --recursive ${NDN_NFD_REPO}
 pushd ./NFD
   git checkout -b build ${NDN_NFD_VERSION}
   ./waf configure --prefix=/
@@ -17,4 +16,4 @@ pushd ./NFD
 popd
 rm -rf ./NFD
 
-cp /usr/local/etc/ndn/nfd.conf.sample /usr/local/etc/ndn/nfd.conf
+cp /etc/ndn/nfd.conf.sample /etc/ndn/nfd.conf

--- a/debian-jessie/scripts/install-nfd.sh
+++ b/debian-jessie/scripts/install-nfd.sh
@@ -8,10 +8,10 @@
 set -e
 cd /source
 
-git clone --depth 1 --recursive https://github.com/felixrabe/NFD.git
+git clone --recursive ${NDN_NFD_REPO}
 pushd ./NFD
-  git checkout -b release-build origin/ndn-start-fg
-  ./waf configure
+  git checkout -b build ${NDN_NFD_VERSION}
+  ./waf configure --prefix=/
   ./waf
   ./waf install
 popd


### PR DESCRIPTION
This makes versions more easily configurable, switches to use nfd-start (and hacks it up to be useable as docker command) and makes sure checkouts are cacheable.
